### PR TITLE
need valid as a transient in domain class

### DIFF
--- a/grails-app/domain/grails/plugin/databasesession/PersistentSession.groovy
+++ b/grails-app/domain/grails/plugin/databasesession/PersistentSession.groovy
@@ -10,6 +10,8 @@ class PersistentSession {
 	Long lastAccessedTime
 	Boolean invalidated = false
 	Integer maxInactiveInterval = 30
+	
+	static transients = ['valid']
 
 	static mapping = {
 		id generator: 'assigned'


### PR DESCRIPTION
Couldn't get this working grails 1.3.x - isValid() triggers an assumption that 'valid' is a property, and the system looks for a setter for 'valid' property, which doesn't exist.
