### PR TITLE
Two small fixes for an Exception and multiple cookies after a session is invalidated.

### DIFF
--- a/DatabaseSessionGrailsPlugin.groovy
+++ b/DatabaseSessionGrailsPlugin.groovy
@@ -5,7 +5,7 @@ import grails.util.Metadata
 import org.springframework.web.filter.DelegatingFilterProxy
 
 class DatabaseSessionGrailsPlugin {
-	String version = '1.1.2'
+	String version = '1.1.3-SNAPSHOT'
 	String grailsVersion = '1.3.3 > *'
 	String title = 'Database Session Plugin'
 	String author = 'Burt Beckwith'

--- a/src/java/grails/plugin/databasesession/SessionProxyFilter.java
+++ b/src/java/grails/plugin/databasesession/SessionProxyFilter.java
@@ -68,7 +68,8 @@ public class SessionProxyFilter extends OncePerRequestFilter {
 
 			// no session cookie but do create
 			log.debug("No session cookie but create is true, creating session");
-			createSession(request, response);
+			sessionId = createSession(request, response);
+			return new SessionProxy(getServletContext(), persister, sessionId);
 		}
 
 		if (persister.isValid(sessionId)) {
@@ -130,7 +131,7 @@ public class SessionProxyFilter extends OncePerRequestFilter {
 		}
 		else {
 			log.debug("Updating existing cookie with id {} to new value {}", cookie.getValue(), sessionId);
-			cookie.setValue(sessionId);
+			cookie = newCookie(sessionId, request);
 		}
 		response.addCookie(cookie);
 	}


### PR DESCRIPTION
I was encountering two small issues with the plugin.

The first was that the first time I visited the application I would get
an AssertionFailed exception.  I believe this is because the null sessionId was being used for a call to invalidate().

17:34:33 web.1     | 2012-03-19 17:34:33,777 [qtp530654357-24 - /] ERROR databasesession.GormPersisterService  - [Assertion failed] - this String argument must have length; it must not be null or empty
17:34:33 web.1     | java.lang.IllegalArgumentException: [Assertion failed] - this String argument must have length; it must not be null or empty
17:34:33 web.1     |    at grails.plugin.databasesession.PersistentSessionAttributeValue.deleteBySessionId(PersistentSessionAttributeValue.groovy:45)
17:34:33 web.1     |    at grails.plugin.databasesession.GormPersisterService.invalidate(GormPersisterService.groovy:111)
17:34:33 web.1     |    at grails.plugin.databasesession.SessionProxyFilter.proxySession(SessionProxyFilter.java:90)
17:34:33 web.1     |    at grails.plugin.databasesession.SessionProxyFilter$1.getSession(SessionProxyFilter.java:42)
17:34:33 web.1     |    at grails.plugin.databasesession.SessionProxyFilter$1.getSession(SessionProxyFilter.java:47)

The second was that after a session was invalidated the application
would create a duplicate session cookie, causing my session information
to get lost.  This happened in Chrome, not sure if that had something
to do with it.  It should now ensure that the cookie that is returned
has the same path and host as the original cookie.

Also revved the version to the next micro plus snapshot.
